### PR TITLE
docs: Update environment variables and version references

### DIFF
--- a/markdown/authentication.mdx
+++ b/markdown/authentication.mdx
@@ -32,7 +32,7 @@ This section provides a detailed guide for integrating Keycloak with Inference G
 ### Prerequisites
 
 - [Keycloak](https://www.keycloak.org/) server (v24.0.0 or later recommended)
-- [Inference Gateway](https://github.com/inference-gateway/inference-gateway) (v0.6.2 or later)
+- [Inference Gateway](https://github.com/inference-gateway/inference-gateway) (v0.7.1 or later)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) for Kubernetes deployment
 - [Helm](https://helm.sh/docs/intro/install/) for chart deployment
 - [Task](https://taskfile.dev/installation/) (optional, for running example tasks)
@@ -167,7 +167,7 @@ helm upgrade --install \
   --namespace inference-gateway \
   --set envFrom.configMapRef=inference-gateway \
   --set envFrom.secretRef=inference-gateway \
-  inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway:0.6.2
+  inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway:0.7.1
 ```
 
 ## Obtaining Access Tokens
@@ -229,7 +229,7 @@ helm upgrade --install \
   --set volumeMounts[0].mountPath=/usr/local/share/ca-certificates/keycloak-ca.crt \
   --set volumeMounts[0].subPath=ca.crt \
   --set volumeMounts[0].readOnly=true \
-  inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway:0.6.2
+  inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway:0.7.1
 ```
 
 ## Best Practices

--- a/markdown/authentication.mdx
+++ b/markdown/authentication.mdx
@@ -32,7 +32,7 @@ This section provides a detailed guide for integrating Keycloak with Inference G
 ### Prerequisites
 
 - [Keycloak](https://www.keycloak.org/) server (v24.0.0 or later recommended)
-- [Inference Gateway](https://github.com/inference-gateway/inference-gateway) (v0.7.1 or later)
+- [Inference Gateway](https://github.com/inference-gateway/inference-gateway) (v0.16.1 or later)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) for Kubernetes deployment
 - [Helm](https://helm.sh/docs/intro/install/) for chart deployment
 - [Task](https://taskfile.dev/installation/) (optional, for running example tasks)
@@ -167,7 +167,7 @@ helm upgrade --install \
   --namespace inference-gateway \
   --set envFrom.configMapRef=inference-gateway \
   --set envFrom.secretRef=inference-gateway \
-  inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway:0.7.1
+  inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway:0.16.1
 ```
 
 ## Obtaining Access Tokens
@@ -229,7 +229,7 @@ helm upgrade --install \
   --set volumeMounts[0].mountPath=/usr/local/share/ca-certificates/keycloak-ca.crt \
   --set volumeMounts[0].subPath=ca.crt \
   --set volumeMounts[0].readOnly=true \
-  inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway:0.7.1
+  inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway:0.16.1
 ```
 
 ## Best Practices

--- a/markdown/configuration.mdx
+++ b/markdown/configuration.mdx
@@ -213,6 +213,19 @@ Configure access to various LLM providers. At minimum, you should configure the 
   ]}
 />
 
+#### Google
+
+<ConfigTable
+  rows={[
+    {
+      variable: 'GOOGLE_API_URL',
+      description: 'Google AI API URL',
+      defaultValue: 'https://generativelanguage.googleapis.com/v1',
+    },
+    { variable: 'GOOGLE_API_KEY', description: 'Google AI API Key', defaultValue: '""' },
+  ]}
+/>
+
 ### Model Context Protocol (MCP) Settings
 
 These settings control MCP integration for external tool access:
@@ -385,6 +398,7 @@ OPENAI_API_KEY=your-openai-api-key
 ANTHROPIC_API_KEY=your-anthropic-api-key
 GROQ_API_KEY=your-groq-api-key
 DEEPSEEK_API_KEY=your-deepseek-api-key
+GOOGLE_API_KEY=your-google-api-key
 
 # Model Context Protocol (MCP) - for external tool integration
 MCP_ENABLE=true

--- a/markdown/configuration.mdx
+++ b/markdown/configuration.mdx
@@ -213,6 +213,93 @@ Configure access to various LLM providers. At minimum, you should configure the 
   ]}
 />
 
+### Model Context Protocol (MCP) Settings
+
+These settings control MCP integration for external tool access:
+
+<ConfigTable
+  rows={[
+    { variable: 'MCP_ENABLE', description: 'Enable MCP middleware', defaultValue: 'false' },
+    {
+      variable: 'MCP_EXPOSE',
+      description: 'Expose MCP endpoints for debugging',
+      defaultValue: 'false',
+    },
+    {
+      variable: 'MCP_SERVERS',
+      description: 'Comma-separated list of MCP server URLs',
+      defaultValue: '""',
+    },
+    { variable: 'MCP_CLIENT_TIMEOUT', description: 'MCP client timeout', defaultValue: '10s' },
+    { variable: 'MCP_DIAL_TIMEOUT', description: 'MCP dial timeout', defaultValue: '5s' },
+    {
+      variable: 'MCP_TLS_HANDSHAKE_TIMEOUT',
+      description: 'MCP TLS handshake timeout',
+      defaultValue: '5s',
+    },
+    {
+      variable: 'MCP_RESPONSE_HEADER_TIMEOUT',
+      description: 'MCP response header timeout',
+      defaultValue: '5s',
+    },
+    {
+      variable: 'MCP_EXPECT_CONTINUE_TIMEOUT',
+      description: 'MCP expect continue timeout',
+      defaultValue: '2s',
+    },
+    { variable: 'MCP_REQUEST_TIMEOUT', description: 'MCP request timeout', defaultValue: '10s' },
+  ]}
+/>
+
+### Agent-to-Agent (A2A) Settings
+
+These settings control A2A protocol integration for agent coordination:
+
+<ConfigTable
+  rows={[
+    { variable: 'A2A_ENABLE', description: 'Enable A2A protocol support', defaultValue: 'false' },
+    {
+      variable: 'A2A_EXPOSE',
+      description: 'Expose A2A endpoints for debugging',
+      defaultValue: 'false',
+    },
+    {
+      variable: 'A2A_AGENTS',
+      description: 'Comma-separated list of A2A agent URLs',
+      defaultValue: '""',
+    },
+    { variable: 'A2A_CLIENT_TIMEOUT', description: 'A2A client timeout', defaultValue: '30s' },
+  ]}
+/>
+
+### UI Settings
+
+These settings control the Inference Gateway UI:
+
+<ConfigTable
+  rows={[
+    {
+      variable: 'INFERENCE_GATEWAY_URL',
+      description: 'The URL of the Inference Gateway server',
+      defaultValue: 'http://localhost:8080/v1',
+    },
+  ]}
+/>
+
+### Logging and Debugging
+
+These settings control logging and debugging behavior:
+
+<ConfigTable
+  rows={[
+    {
+      variable: 'LOG_LEVEL',
+      description: 'Set logging level (debug, info, warn, error)',
+      defaultValue: 'info',
+    },
+  ]}
+/>
+
 ## Environment Variable File (.env)
 
 For local development, you can use a `.env` file. Create a file named `.env` in your project root:
@@ -297,6 +384,26 @@ CLIENT_TLS_MIN_VERSION=TLS12
 OPENAI_API_KEY=your-openai-api-key
 ANTHROPIC_API_KEY=your-anthropic-api-key
 GROQ_API_KEY=your-groq-api-key
+DEEPSEEK_API_KEY=your-deepseek-api-key
+
+# Model Context Protocol (MCP) - for external tool integration
+MCP_ENABLE=true
+MCP_EXPOSE=false  # Set to true for debugging
+MCP_SERVERS=http://time-server:8081/mcp,http://search-server:8082/mcp
+MCP_CLIENT_TIMEOUT=10s
+MCP_REQUEST_TIMEOUT=10s
+
+# Agent-to-Agent (A2A) - for agent coordination
+A2A_ENABLE=true
+A2A_EXPOSE=false  # Set to true for debugging
+A2A_AGENTS=http://google-calendar-agent:8084
+A2A_CLIENT_TIMEOUT=30s
+
+# UI settings (if using UI)
+INFERENCE_GATEWAY_URL=https://api.example.com/v1
+
+# Logging
+LOG_LEVEL=info  # Use 'debug' for troubleshooting
 ```
 
 ## Configuration Best Practices

--- a/markdown/deployment.mdx
+++ b/markdown/deployment.mdx
@@ -23,7 +23,7 @@ Install the chart directly from OCI registry:
 helm upgrade --install inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway \
   --namespace inference-gateway \
   --create-namespace \
-  --version 0.7.1
+  --version 0.16.1
 ```
 
 To enable ingress for the basic deployment:
@@ -33,7 +33,7 @@ helm upgrade --install inference-gateway oci://ghcr.io/inference-gateway/charts/
   --namespace inference-gateway \
   --create-namespace \
   --set ingress.enabled=true \
-  --version 0.7.1
+  --version 0.16.1
 ```
 
 ### Option 2: UI with Gateway Deployment
@@ -206,7 +206,7 @@ To upgrade an existing installation:
 helm upgrade --install inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway \
   --namespace inference-gateway \
   -f values.yaml \
-  --version 0.7.1
+  --version 0.16.1
 
 # For UI with gateway
 helm upgrade --install inference-gateway-ui oci://ghcr.io/inference-gateway/charts/inference-gateway-ui \

--- a/markdown/deployment.mdx
+++ b/markdown/deployment.mdx
@@ -23,7 +23,7 @@ Install the chart directly from OCI registry:
 helm upgrade --install inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway \
   --namespace inference-gateway \
   --create-namespace \
-  --version 0.6.2
+  --version 0.7.1
 ```
 
 To enable ingress for the basic deployment:
@@ -33,7 +33,7 @@ helm upgrade --install inference-gateway oci://ghcr.io/inference-gateway/charts/
   --namespace inference-gateway \
   --create-namespace \
   --set ingress.enabled=true \
-  --version 0.6.2
+  --version 0.7.1
 ```
 
 ### Option 2: UI with Gateway Deployment
@@ -206,7 +206,7 @@ To upgrade an existing installation:
 helm upgrade --install inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway \
   --namespace inference-gateway \
   -f values.yaml \
-  --version 0.6.2
+  --version 0.7.1
 
 # For UI with gateway
 helm upgrade --install inference-gateway-ui oci://ghcr.io/inference-gateway/charts/inference-gateway-ui \

--- a/markdown/examples.mdx
+++ b/markdown/examples.mdx
@@ -11,7 +11,7 @@ Docker Compose provides a simple way to set up Inference Gateway with various co
 A minimal setup with OpenAI integration:
 
 ```yaml
-version: '3'
+version: '3.8'
 services:
   inference-gateway:
     image: ghcr.io/inference-gateway/inference-gateway:latest
@@ -65,7 +65,7 @@ For complete Kubernetes deployment examples including Services, ConfigMaps, and 
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "openai/gpt-4",
+    "model": "openai/gpt-4o",
     "messages": [
       {
         "role": "system",
@@ -85,7 +85,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "anthropic/claude-3-opus-20240229",
+    "model": "anthropic/claude-3-5-sonnet-20241022",
     "messages": [
       {
         "role": "system",

--- a/markdown/examples.mdx
+++ b/markdown/examples.mdx
@@ -11,7 +11,6 @@ Docker Compose provides a simple way to set up Inference Gateway with various co
 A minimal setup with OpenAI integration:
 
 ```yaml
-version: '3.8'
 services:
   inference-gateway:
     image: ghcr.io/inference-gateway/inference-gateway:latest

--- a/markdown/getting-started.mdx
+++ b/markdown/getting-started.mdx
@@ -26,7 +26,7 @@ Send a request to the Inference Gateway:
 ```bash
 curl -X POST http://localhost:8080/v1/chat/completions \
 -d '{
-"model": "gpt-4o-mini",
+"model": "openai/gpt-4o-mini",
 "messages": [
         {
             "role": "system",

--- a/markdown/getting-started.mdx
+++ b/markdown/getting-started.mdx
@@ -26,7 +26,7 @@ Send a request to the Inference Gateway:
 ```bash
 curl -X POST http://localhost:8080/v1/chat/completions \
 -d '{
-"model": "gpt-3.5-turbo",
+"model": "gpt-4o-mini",
 "messages": [
         {
             "role": "system",

--- a/markdown/main.mdx
+++ b/markdown/main.mdx
@@ -61,7 +61,7 @@ export MCP_SERVERS="http://filesystem-server:8081/mcp,http://search-server:8082/
 
 # LLMs automatically get access to all available tools
 curl -X POST http://localhost:8080/v1/chat/completions \
-  -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "List files and search for recent AI news"}]}'
+  -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "List files and search for recent AI news"}]}'
 ```
 
 Learn more about <Link href="/mcp">MCP Integration</Link> and explore our comprehensive examples.

--- a/markdown/main.mdx
+++ b/markdown/main.mdx
@@ -61,7 +61,7 @@ export MCP_SERVERS="http://filesystem-server:8081/mcp,http://search-server:8082/
 
 # LLMs automatically get access to all available tools
 curl -X POST http://localhost:8080/v1/chat/completions \
-  -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "List files and search for recent AI news"}]}'
+  -d '{"model": "openai/gpt-4o", "messages": [{"role": "user", "content": "List files and search for recent AI news"}]}'
 ```
 
 Learn more about <Link href="/mcp">MCP Integration</Link> and explore our comprehensive examples.

--- a/markdown/mcp.mdx
+++ b/markdown/mcp.mdx
@@ -124,7 +124,7 @@ Once configured, MCP tools are automatically available to all LLM requests:
 curl -X POST http://localhost:8080/v1/chat/completions \\
   -H "Content-Type: application/json" \\
   -d '{
-    "model": "gpt-4o",
+    "model": "openai/gpt-4o",
     "messages": [
       {
         "role": "user",
@@ -142,7 +142,7 @@ MCP works seamlessly with streaming responses:
 curl -X POST http://localhost:8080/v1/chat/completions \\
   -H "Content-Type: application/json" \\
   -d '{
-    "model": "gpt-4o",
+    "model": "openai/gpt-4o",
     "messages": [
       {
         "role": "user",

--- a/markdown/mcp.mdx
+++ b/markdown/mcp.mdx
@@ -124,7 +124,7 @@ Once configured, MCP tools are automatically available to all LLM requests:
 curl -X POST http://localhost:8080/v1/chat/completions \\
   -H "Content-Type: application/json" \\
   -d '{
-    "model": "gpt-4",
+    "model": "gpt-4o",
     "messages": [
       {
         "role": "user",
@@ -142,7 +142,7 @@ MCP works seamlessly with streaming responses:
 curl -X POST http://localhost:8080/v1/chat/completions \\
   -H "Content-Type: application/json" \\
   -d '{
-    "model": "gpt-4",
+    "model": "gpt-4o",
     "messages": [
       {
         "role": "user",

--- a/markdown/supported-providers.mdx
+++ b/markdown/supported-providers.mdx
@@ -297,7 +297,7 @@ Generate content with Google's Gemini models:
 curl -X POST http://localhost:8080/v1/chat/completions?provider=google \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gemini-pro",
+    "model": "google/gemini-pro",
     "messages": [
       {
         "role": "system",

--- a/markdown/supported-providers.mdx
+++ b/markdown/supported-providers.mdx
@@ -57,6 +57,13 @@ The following LLM providers are currently supported:
     <p><strong>Authentication:</strong> None (optional API key)</p>
     <p><strong>Default URL:</strong> http://ollama:8080/v1</p>
   </div>
+  
+  <div className="border p-4 rounded-md">
+    <h3>Google</h3>
+    <p>Access Google's Gemini models for text generation and understanding.</p>
+    <p><strong>Authentication:</strong> Bearer Token</p>
+    <p><strong>Default URL:</strong> https://generativelanguage.googleapis.com/v1</p>
+  </div>
 </div>
 
 ## Using Providers
@@ -68,7 +75,7 @@ Each provider requires specific configuration through environment variables:
 - `PROVIDER_API_URL`: The base URL for the provider's API
 - `PROVIDER_API_KEY`: The authentication key for the provider
 
-Replace "PROVIDER" with the provider name (uppercase): OPENAI, ANTHROPIC, COHERE, GROQ, CLOUDFLARE, OLLAMA.
+Replace "PROVIDER" with the provider name (uppercase): OPENAI, ANTHROPIC, COHERE, GROQ, CLOUDFLARE, OLLAMA, GOOGLE, DEEPSEEK.
 
 ### API Endpoints
 
@@ -277,6 +284,28 @@ curl -X POST http://localhost:8080/v1/chat/completions?provider=ollama \
       {
         "role": "user",
         "content": "Write a function to calculate Fibonacci numbers in Python."
+      }
+    ]
+  }'
+```
+
+### Google Provider
+
+Generate content with Google's Gemini models:
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions?provider=google \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-pro",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant."
+      },
+      {
+        "role": "user",
+        "content": "Explain the concept of machine learning in simple terms."
       }
     ]
   }'


### PR DESCRIPTION
This PR updates the Inference Gateway documentation with the latest configuration variables and version references.

## Changes

- Add comprehensive MCP, A2A, UI, and logging environment variables to main configuration documentation
- Standardize Helm chart versions to 0.7.1 across all deployment examples
- Update Inference Gateway version requirement to v0.7.1 or later
- Standardize Docker Compose versions to 3.8 for consistency
- Update model examples to current versions (gpt-4o, gpt-4o-mini, claude-3-5-sonnet)
- Expand complete configuration example with all new variables

## Fixes

Closes #7

Generated with [Claude Code](https://claude.ai/code)