### PR TITLE
docs(auth): Fix OIDC env var names to match upstream gateway

### DIFF
--- a/markdown/api-reference.mdx
+++ b/markdown/api-reference.mdx
@@ -17,7 +17,7 @@ Authorization: Bearer YOUR_JWT_TOKEN
 ```
 
 The JWT token is issued by the configured Identity Provider (IdP) as specified in the OpenID Connect settings
-(`OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, etc.). Inference Gateway validates these tokens
+(`AUTH_OIDC_ISSUER`, `AUTH_OIDC_CLIENT_ID`, etc.). Inference Gateway validates these tokens
 against the IdP to authenticate requests.
 
 ## API Endpoints

--- a/markdown/authentication.mdx
+++ b/markdown/authentication.mdx
@@ -20,9 +20,9 @@ To enable authentication, set the following environment variables:
 
 ```bash
 AUTH_ENABLE=true
-OIDC_ISSUER_URL=https://your-keycloak-instance/realms/your-realm
-OIDC_CLIENT_ID=your-client-id
-OIDC_CLIENT_SECRET=your-client-secret
+AUTH_OIDC_ISSUER=https://your-keycloak-instance/realms/your-realm
+AUTH_OIDC_CLIENT_ID=your-client-id
+AUTH_OIDC_CLIENT_SECRET=your-client-secret
 ```
 
 ## Keycloak Integration
@@ -125,9 +125,9 @@ Update your Inference Gateway configuration to enable authentication:
 
 ```bash
 AUTH_ENABLE=true
-OIDC_ISSUER_URL=https://your-keycloak-instance/realms/inference-gateway-realm
-OIDC_CLIENT_ID=inference-gateway-client
-OIDC_CLIENT_SECRET=your-client-secret
+AUTH_OIDC_ISSUER=https://your-keycloak-instance/realms/inference-gateway-realm
+AUTH_OIDC_CLIENT_ID=inference-gateway-client
+AUTH_OIDC_CLIENT_SECRET=your-client-secret
 ```
 
 #### Using Kubernetes ConfigMap and Secret
@@ -141,7 +141,7 @@ metadata:
   namespace: inference-gateway
 data:
   AUTH_ENABLE: 'true'
-  OIDC_ISSUER_URL: https://your-keycloak-instance/realms/inference-gateway-realm
+  AUTH_OIDC_ISSUER: https://your-keycloak-instance/realms/inference-gateway-realm
 
 ---
 # Secret
@@ -151,8 +151,8 @@ metadata:
   name: inference-gateway
   namespace: inference-gateway
 stringData:
-  OIDC_CLIENT_ID: inference-gateway-client
-  OIDC_CLIENT_SECRET: your-client-secret
+  AUTH_OIDC_CLIENT_ID: inference-gateway-client
+  AUTH_OIDC_CLIENT_SECRET: your-client-secret
 type: Opaque
 ```
 
@@ -243,7 +243,7 @@ helm upgrade --install \
 
 1. **401 Unauthorized Errors**:
    - Check that the token hasn't expired
-   - Verify that OIDC_ISSUER_URL is correct
+   - Verify that AUTH_OIDC_ISSUER is correct
    - Ensure the client secret is valid
 
 2. **Certificate Issues**:

--- a/markdown/configuration.mdx
+++ b/markdown/configuration.mdx
@@ -46,16 +46,16 @@ If authentication is enabled (`AUTH_ENABLE=true`), configure the following OIDC 
 <ConfigTable
   rows={[
     {
-      variable: 'OIDC_ISSUER_URL',
+      variable: 'AUTH_OIDC_ISSUER',
       description: 'OIDC issuer URL',
       defaultValue: 'http://keycloak:8080/realms/inference-gateway-realm',
     },
     {
-      variable: 'OIDC_CLIENT_ID',
+      variable: 'AUTH_OIDC_CLIENT_ID',
       description: 'OIDC client ID',
       defaultValue: 'inference-gateway-client',
     },
-    { variable: 'OIDC_CLIENT_SECRET', description: 'OIDC client secret', defaultValue: '""' },
+    { variable: 'AUTH_OIDC_CLIENT_SECRET', description: 'OIDC client secret', defaultValue: '""' },
   ]}
 />
 
@@ -363,7 +363,7 @@ data:
   ANTHROPIC_API_KEY: '<base64-encoded-key>'
   COHERE_API_KEY: '<base64-encoded-key>'
   OPENAI_API_KEY: '<base64-encoded-key>'
-  OIDC_CLIENT_SECRET: '<base64-encoded-key>'
+  AUTH_OIDC_CLIENT_SECRET: '<base64-encoded-key>'
 ```
 
 ## Complete Configuration Example


### PR DESCRIPTION
## Summary

The OIDC env vars documented in `markdown/authentication.mdx`, `markdown/configuration.mdx`, and `markdown/api-reference.mdx` did not match what the gateway actually reads, so users following the docs ended up with a non-functional auth setup.

| Documented (wrong) | Actual (per upstream `Configurations.md`) |
| --- | --- |
| `OIDC_ISSUER_URL` | `AUTH_OIDC_ISSUER` |
| `OIDC_CLIENT_ID` | `AUTH_OIDC_CLIENT_ID` |
| `OIDC_CLIENT_SECRET` | `AUTH_OIDC_CLIENT_SECRET` |

Also resolves the internal contradiction in `configuration.mdx` where the OpenID Connect table disagreed with the "Complete Configuration Example" block at the bottom of the same file.

## Files changed

- `markdown/authentication.mdx` -- env setup, Docker example, ConfigMap/Secret example, troubleshooting checklist
- `markdown/configuration.mdx` -- OpenID Connect `ConfigTable` + Kubernetes Secret example
- `markdown/api-reference.mdx` -- inline reference at line 20 (same drift, not in original issue)

## Verification

- Defaults cross-checked against `inference-gateway/inference-gateway` `Configurations.md` via `gh api`.
- `npm run format:check` passes.
- `npm run lint:md` passes.

Closes #48

Generated with [Claude Code](https://claude.ai/code)