### PR TITLE
docs(github-action): add moonshot-api-key input

### DIFF
--- a/github-action.md
+++ b/github-action.md
@@ -96,6 +96,7 @@ The override is parsed by the action's trigger-detection step and exported as `I
 | `cohere-api-key`          | No\*     | -         | Required when using a Cohere model.                                                                        |
 | `ollama-api-key`          | No\*     | -         | Required when using a self-hosted Ollama endpoint.                                                         |
 | `ollama-cloud-api-key`    | No\*     | -         | Required when using Ollama Cloud.                                                                          |
+| `moonshot-api-key`        | No\*     | -         | Required when using a Moonshot (Kimi) model.                                                               |
 
 \* Provide the key matching the provider of the chosen `model`. Multiple keys can be supplied so the same workflow handles overrides to different providers.
 


### PR DESCRIPTION
## Summary

The infer-action inputs table on the GitHub Action page enumerated every provider api-key input except Moonshot, even though the gateway provider matrix already documents Moonshot. This adds the missing `moonshot-api-key` row so the page matches the action.

Companion to inference-gateway/infer-action#29, which wires the `moonshot-api-key` input through the action itself.

## Change

- `github-action.md` - add a `moonshot-api-key` row to the inputs table (after `ollama-cloud-api-key`).

## Verification

- `npm run format:check` passes
- `npm run lint:md` passes

Closes #90
Refs inference-gateway/infer-action#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
