### PR TITLE
docs: document chat completion schema gaps

### DIFF
--- a/api-reference.md
+++ b/api-reference.md
@@ -596,12 +596,12 @@ Returned by `POST /v1/chat/completions` when `stream: false`.
 
 One element of the `choices` array in a `CreateChatCompletionResponse`.
 
-| Field           | Type               | Description                      |
-| --------------- | ------------------ | -------------------------------- |
-| `index`         | `integer`          | Choice index                     |
-| `message`       | `Message`          | The generated message            |
-| `finish_reason` | `FinishReason`     | Why the model stopped generating |
-| `logprobs`      | `object` \| `null` | Token log-probability groups     |
+| Field           | Type                                   | Description                      |
+| --------------- | -------------------------------------- | -------------------------------- |
+| `index`         | `integer`                              | Choice index                     |
+| `message`       | `Message`                              | The generated message            |
+| `finish_reason` | `FinishReason`                         | Why the model stopped generating |
+| `logprobs`      | `ChatCompletionTokenLogprob` \| `null` | Token log-probability groups     |
 
 When present, `logprobs` contains `content` and `refusal` arrays of
 `ChatCompletionTokenLogprob` objects.

--- a/api-reference.md
+++ b/api-reference.md
@@ -615,7 +615,6 @@ Why the model stopped generating tokens. One of:
 | `"stop"`           | Natural end of output or stop sequence hit |
 | `"length"`         | `max_tokens` limit reached                 |
 | `"tool_calls"`     | Model issued one or more tool calls        |
-| `"function_call"`  | Model issued a legacy function call        |
 | `"content_filter"` | Output was filtered                        |
 
 #### `CompletionUsage`
@@ -632,12 +631,12 @@ Token usage statistics returned in both streaming and non-streaming responses.
 
 Per-token log-probability information, present when `logprobs: true` is requested.
 
-| Field          | Type        | Description                  |
-| -------------- | ----------- | ---------------------------- |
-| `token`        | `string`    | The token string             |
-| `logprob`      | `number`    | Log probability of the token |
-| `bytes`        | `integer[]` | UTF-8 bytes of the token     |
-| `top_logprobs` | `object[]`  | Top alternative tokens       |
+| Field          | Type                           | Description                  |
+| -------------- | ------------------------------ | ---------------------------- |
+| `token`        | `string`                       | The token string             |
+| `logprob`      | `number`                       | Log probability of the token |
+| `bytes`        | `integer[]`                    | UTF-8 bytes of the token     |
+| `top_logprobs` | `ChatCompletionTokenLogprob[]` | Top alternative tokens       |
 
 ### Streaming Response Schemas
 

--- a/api-reference.md
+++ b/api-reference.md
@@ -596,12 +596,12 @@ Returned by `POST /v1/chat/completions` when `stream: false`.
 
 One element of the `choices` array in a `CreateChatCompletionResponse`.
 
-| Field           | Type                                   | Description                      |
-| --------------- | -------------------------------------- | -------------------------------- |
-| `index`         | `integer`                              | Choice index                     |
-| `message`       | `Message`                              | The generated message            |
-| `finish_reason` | `FinishReason`                         | Why the model stopped generating |
-| `logprobs`      | `ChatCompletionTokenLogprob` \| `null` | Token log-probability groups     |
+| Field           | Type                                     | Description                      |
+| --------------- | ---------------------------------------- | -------------------------------- |
+| `index`         | `integer`                                | Choice index                     |
+| `message`       | `Message`                                | The generated message            |
+| `finish_reason` | `FinishReason`                           | Why the model stopped generating |
+| `logprobs`      | `ChatCompletionTokenLogprob[]` \| `null` | Token log-probability groups     |
 
 When present, `logprobs` contains `content` and `refusal` arrays of
 `ChatCompletionTokenLogprob` objects.

--- a/api-reference.md
+++ b/api-reference.md
@@ -507,15 +507,16 @@ The raw response body returned by proxy endpoints (`{METHOD} /proxy/{provider}/{
 
 The body sent to `POST /v1/chat/completions`.
 
-| Field            | Type                          | Required | Description                                             |
-| ---------------- | ----------------------------- | -------- | ------------------------------------------------------- |
-| `model`          | `string`                      | Yes      | Model identifier (e.g., `"deepseek/deepseek-v4-flash"`) |
-| `messages`       | `Message[]`                   | Yes      | Conversation history                                    |
-| `stream`         | `boolean`                     |          | Enable SSE streaming (default: `false`)                 |
-| `stream_options` | `ChatCompletionStreamOptions` |          | Streaming behaviour options                             |
-| `max_tokens`     | `integer`                     |          | Maximum tokens to generate                              |
-| `tools`          | `ChatCompletionTool[]`        |          | Tools available to the model                            |
-| `temperature`    | `number`                      |          | Sampling temperature (0-2)                              |
+| Field              | Type                          | Required | Description                                             |
+| ------------------ | ----------------------------- | -------- | ------------------------------------------------------- |
+| `model`            | `string`                      | Yes      | Model identifier (e.g., `"deepseek/deepseek-v4-flash"`) |
+| `messages`         | `Message[]`                   | Yes      | Conversation history                                    |
+| `stream`           | `boolean`                     |          | Enable SSE streaming (default: `false`)                 |
+| `stream_options`   | `ChatCompletionStreamOptions` |          | Streaming behaviour options                             |
+| `max_tokens`       | `integer`                     |          | Maximum tokens to generate                              |
+| `tools`            | `ChatCompletionTool[]`        |          | Tools available to the model                            |
+| `temperature`      | `number`                      |          | Sampling temperature (0-2)                              |
+| `reasoning_format` | `string`                      |          | Reasoning output format: `"raw"` or `"parsed"`          |
 
 #### `ChatCompletionStreamOptions`
 
@@ -526,6 +527,19 @@ Controls streaming behaviour when `stream: true`.
 | `include_usage` | `boolean` | Include a final `CompletionUsage` chunk at the end of the stream |
 
 ### Message Content
+
+#### `Message`
+
+One element of the `messages` array in a `CreateChatCompletionRequest`.
+
+| Field               | Type                              | Required | Description                                 |
+| ------------------- | --------------------------------- | -------- | ------------------------------------------- |
+| `role`              | `MessageRole`                     | Yes      | Role of the message sender                  |
+| `content`           | `MessageContent`                  | Yes      | Text or multimodal message content          |
+| `tool_calls`        | `ChatCompletionMessageToolCall[]` |          | Tool calls returned by an assistant message |
+| `tool_call_id`      | `string`                          |          | Tool-call ID for a tool response message    |
+| `reasoning_content` | `string`                          |          | Reasoning content emitted by the provider   |
+| `reasoning`         | `string`                          |          | Alias for `reasoning_content`               |
 
 #### `MessageRole`
 
@@ -582,12 +596,15 @@ Returned by `POST /v1/chat/completions` when `stream: false`.
 
 One element of the `choices` array in a `CreateChatCompletionResponse`.
 
-| Field           | Type                           | Description                        |
-| --------------- | ------------------------------ | ---------------------------------- |
-| `index`         | `integer`                      | Choice index                       |
-| `message`       | `Message`                      | The generated message              |
-| `finish_reason` | `FinishReason`                 | Why the model stopped generating   |
-| `logprobs`      | `ChatCompletionTokenLogprob[]` | Log probabilities (when requested) |
+| Field           | Type               | Description                      |
+| --------------- | ------------------ | -------------------------------- |
+| `index`         | `integer`          | Choice index                     |
+| `message`       | `Message`          | The generated message            |
+| `finish_reason` | `FinishReason`     | Why the model stopped generating |
+| `logprobs`      | `object` \| `null` | Token log-probability groups     |
+
+When present, `logprobs` contains `content` and `refusal` arrays of
+`ChatCompletionTokenLogprob` objects.
 
 #### `FinishReason`
 
@@ -598,6 +615,7 @@ Why the model stopped generating tokens. One of:
 | `"stop"`           | Natural end of output or stop sequence hit |
 | `"length"`         | `max_tokens` limit reached                 |
 | `"tool_calls"`     | Model issued one or more tool calls        |
+| `"function_call"`  | Model issued a legacy function call        |
 | `"content_filter"` | Output was filtered                        |
 
 #### `CompletionUsage`
@@ -614,12 +632,12 @@ Token usage statistics returned in both streaming and non-streaming responses.
 
 Per-token log-probability information, present when `logprobs: true` is requested.
 
-| Field          | Type                           | Description                  |
-| -------------- | ------------------------------ | ---------------------------- |
-| `token`        | `string`                       | The token string             |
-| `logprob`      | `number`                       | Log probability of the token |
-| `bytes`        | `integer[]`                    | UTF-8 bytes of the token     |
-| `top_logprobs` | `ChatCompletionTokenLogprob[]` | Top alternative tokens       |
+| Field          | Type        | Description                  |
+| -------------- | ----------- | ---------------------------- |
+| `token`        | `string`    | The token string             |
+| `logprob`      | `number`    | Log probability of the token |
+| `bytes`        | `integer[]` | UTF-8 bytes of the token     |
+| `top_logprobs` | `object[]`  | Top alternative tokens       |
 
 ### Streaming Response Schemas
 
@@ -627,14 +645,15 @@ Per-token log-probability information, present when `logprobs: true` is requeste
 
 Returned by `POST /v1/chat/completions` when `stream: true`. Each SSE event carries one of these objects in its `data` field.
 
-| Field     | Type                           | Description                                       |
-| --------- | ------------------------------ | ------------------------------------------------- |
-| `id`      | `string`                       | Unique completion identifier (same across chunks) |
-| `object`  | `string`                       | Always `"chat.completion.chunk"`                  |
-| `created` | `integer`                      | Unix timestamp                                    |
-| `model`   | `string`                       | Model used                                        |
-| `choices` | `ChatCompletionStreamChoice[]` | Streaming choices (empty in the usage chunk)      |
-| `usage`   | `CompletionUsage`              | Present only in the final usage chunk             |
+| Field              | Type                           | Description                                       |
+| ------------------ | ------------------------------ | ------------------------------------------------- |
+| `id`               | `string`                       | Unique completion identifier (same across chunks) |
+| `object`           | `string`                       | Always `"chat.completion.chunk"`                  |
+| `created`          | `integer`                      | Unix timestamp                                    |
+| `model`            | `string`                       | Model used                                        |
+| `choices`          | `ChatCompletionStreamChoice[]` | Streaming choices (empty in the usage chunk)      |
+| `usage`            | `CompletionUsage`              | Present only in the final usage chunk             |
+| `reasoning_format` | `string`                       | Reasoning output format: `"raw"` or `"parsed"`    |
 
 #### `SSEvent`
 
@@ -654,17 +673,20 @@ One element of the `choices` array in a `CreateChatCompletionStreamResponse`.
 | --------------- | ----------------------------------- | ----------------------------------- |
 | `index`         | `integer`                           | Choice index                        |
 | `delta`         | `ChatCompletionStreamResponseDelta` | Incremental content for this chunk  |
+| `logprobs`      | `object`                            | Token log-probability groups        |
 | `finish_reason` | `FinishReason` \| `null`            | Set on the final chunk for a choice |
 
 #### `ChatCompletionStreamResponseDelta`
 
 The incremental content carried by each `ChatCompletionStreamChoice`.
 
-| Field        | Type                                   | Description                                         |
-| ------------ | -------------------------------------- | --------------------------------------------------- |
-| `role`       | `MessageRole`                          | Sent once in the first chunk (`"assistant"`)        |
-| `content`    | `string`                               | Partial text content                                |
-| `tool_calls` | `ChatCompletionMessageToolCallChunk[]` | Partial tool-call data (when the model calls tools) |
+| Field               | Type                                   | Description                                         |
+| ------------------- | -------------------------------------- | --------------------------------------------------- |
+| `role`              | `MessageRole`                          | Sent once in the first chunk (`"assistant"`)        |
+| `content`           | `string`                               | Partial text content                                |
+| `reasoning_content` | `string`                               | Partial reasoning content                           |
+| `reasoning`         | `string`                               | Alias for `reasoning_content`                       |
+| `tool_calls`        | `ChatCompletionMessageToolCallChunk[]` | Partial tool-call data (when the model calls tools) |
 
 #### `ChatCompletionMessageToolCallChunk`
 


### PR DESCRIPTION
Fixes #203.

## Summary
- document schema-backed `reasoning_format` fields for chat-completion requests and streaming responses
- add the missing `Message` field table for tool-call and reasoning fields
- correct the documented `logprobs` / `ChatCompletionTokenLogprob` shapes and include schema-backed streaming logprob/reasoning fields

## Validation
- `npm ci` (completed; npm warned that local Node `v22.22.3` does not satisfy the repo engine `^24.15.0`)
- `npm run format:check`
- `npm run lint:md`
- `npm run build`