### PR TITLE
ci: move docs deployment and PR previews to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,21 @@ jobs:
       name: github-pages
       url: https://docs.inference-gateway.com
     steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+
+      - name: Get bot user id
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
@@ -46,6 +61,9 @@ jobs:
       - name: Deploy to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
+          git-config-name: ${{ steps.app-token.outputs.app-slug }}[bot]
+          git-config-email: ${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
           folder: .vitepress/dist
           branch: gh-pages
           clean-exclude: pr-preview/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
         run: bun run build
 
       - name: Deploy to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@v4.9.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           git-config-name: ${{ steps.app-token.outputs.app-slug }}[bot]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,6 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-24.04
-    environment:
-      name: github-pages
-      url: https://docs.inference-gateway.com
     steps:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,18 +15,19 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build
+  deploy:
+    name: Deploy
     runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: https://docs.inference-gateway.com
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -42,22 +43,9 @@ jobs:
       - name: Build static site
         run: bun run build
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v6.0.0
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5.0.0
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: .vitepress/dist
-
-  deploy:
-    name: Deploy
-    needs: build
-    runs-on: ubuntu-24.04
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5.0.0
+          folder: .vitepress/dist
+          branch: gh-pages
+          clean-exclude: pr-preview/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Build static site
         run: bun run build
 
-      - name: Deploy to Cloudflare Pages
-        run: bunx wrangler@4.123.0 pages deploy .vitepress/dist --project-name inference-gateway-docs --branch main
+      - name: Deploy to Cloudflare Workers
+        run: bunx wrangler@4.123.0 deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: pages
@@ -25,22 +25,10 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-24.04
+    environment:
+      name: production
+      url: https://docs.inference-gateway.com
     steps:
-      - uses: actions/create-github-app-token@v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ secrets.RELEASER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            ${{ github.event.repository.name }}
-
-      - name: Get bot user id
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
@@ -55,12 +43,8 @@ jobs:
       - name: Build static site
         run: bun run build
 
-      - name: Deploy to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4.9.0
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          git-config-name: ${{ steps.app-token.outputs.app-slug }}[bot]
-          git-config-email: ${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
-          folder: .vitepress/dist
-          branch: gh-pages
-          clean-exclude: pr-preview/
+      - name: Deploy to Cloudflare Pages
+        run: bunx wrangler@4.123.0 pages deploy .vitepress/dist --project-name inference-gateway-docs --branch main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,8 +21,6 @@ jobs:
   preview:
     name: Deploy preview
     runs-on: ubuntu-24.04
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token
@@ -54,6 +52,8 @@ jobs:
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         with:
           token: ${{ steps.app-token.outputs.token }}
           source-dir: .vitepress/dist

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,9 +17,6 @@ concurrency:
   group: preview-${{ github.event.number }}
   cancel-in-progress: true
 
-env:
-  PAGES_PROJECT: inference-gateway-docs
-
 jobs:
   preview:
     name: Deploy preview
@@ -44,8 +41,8 @@ jobs:
         id: alias
         run: echo "alias=$(echo "$GITHUB_HEAD_REF" | tr '/_.' '---' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-*$//')" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy to Cloudflare Pages
-        run: bunx wrangler@4.123.0 pages deploy .vitepress/dist --project-name "$PAGES_PROJECT" --branch "$GITHUB_HEAD_REF" --commit-dirty=true
+      - name: Upload preview version
+        run: bunx wrangler@4.123.0 versions upload --preview-alias "${{ steps.alias.outputs.alias }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -62,18 +59,21 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-24.04
     steps:
-      - name: Delete branch deployments
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Resolve branch alias
+        id: alias
+        run: echo "alias=$(echo "$GITHUB_HEAD_REF" | tr '/_.' '---' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-*$//')" >> "$GITHUB_OUTPUT"
+
+      - name: Point alias at a tombstone version
         run: |
-          base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PAGES_PROJECT"
-          for id in $(curl -sf -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$base/deployments?env=preview&per_page=25" \
-            | jq -r --arg b "$GITHUB_HEAD_REF" '.result[] | select(.deployment_trigger.metadata.branch == $b) | .id'); do
-            echo "Deleting deployment $id"
-            curl -sf -X DELETE -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$base/deployments/$id?force=true" > /dev/null
-          done
+          mkdir -p .tombstone
+          printf '<!doctype html><title>Preview destroyed</title><h1>410</h1><p>This preview environment was destroyed when its pull request closed.</p>' > .tombstone/index.html
+          bunx wrangler@4.123.0 versions upload --assets .tombstone --preview-alias "${{ steps.alias.outputs.alias }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
 
       - name: Comment removal
         uses: marocchino/sticky-pull-request-comment@v3.0.5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,6 +22,15 @@ jobs:
     name: Deploy preview
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
@@ -44,4 +53,5 @@ jobs:
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           source-dir: .vitepress/dist

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,51 +10,74 @@ on:
       - closed
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 concurrency:
   group: preview-${{ github.event.number }}
   cancel-in-progress: true
 
+env:
+  PAGES_PROJECT: inference-gateway-docs
+
 jobs:
   preview:
     name: Deploy preview
+    if: github.event.action != 'closed'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/create-github-app-token@v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ secrets.RELEASER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            ${{ github.event.repository.name }}
-
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
-        if: github.event.action != 'closed'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version
 
       - name: Install dependencies
-        if: github.event.action != 'closed'
         run: bun install --frozen-lockfile
 
       - name: Build static site
-        if: github.event.action != 'closed'
         run: bun run build
-        env:
-          DOCS_BASE: /pr-preview/pr-${{ github.event.number }}/
 
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+      - name: Resolve branch alias
+        id: alias
+        run: echo "alias=$(echo "$GITHUB_HEAD_REF" | tr '/_.' '---' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-*$//')" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Cloudflare Pages
+        run: bunx wrangler@4.123.0 pages deploy .vitepress/dist --project-name "$PAGES_PROJECT" --branch "$GITHUB_HEAD_REF" --commit-dirty=true
         env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Comment preview URL
+        uses: marocchino/sticky-pull-request-comment@v3.0.5
         with:
-          token: ${{ steps.app-token.outputs.token }}
-          source-dir: .vitepress/dist
-          custom-url: docs.inference-gateway.com
+          header: preview
+          message: |
+            :rocket: Preview deployed: https://preview-${{ steps.alias.outputs.alias }}.inference-gateway.com
+
+  teardown:
+    name: Destroy preview
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Delete branch deployments
+        run: |
+          base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PAGES_PROJECT"
+          for id in $(curl -sf -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$base/deployments?env=preview&per_page=25" \
+            | jq -r --arg b "$GITHUB_HEAD_REF" '.result[] | select(.deployment_trigger.metadata.branch == $b) | .id'); do
+            echo "Deleting deployment $id"
+            curl -sf -X DELETE -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$base/deployments/$id?force=true" > /dev/null
+          done
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+
+      - name: Comment removal
+        uses: marocchino/sticky-pull-request-comment@v3.0.5
+        with:
+          header: preview
+          message: |
+            :wastebasket: Preview environment destroyed.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -55,3 +55,4 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           source-dir: .vitepress/dist
+          custom-url: docs.inference-gateway.com

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,6 +21,8 @@ jobs:
   preview:
     name: Deploy preview
     runs-on: ubuntu-24.04
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,47 @@
+---
+name: Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Deploy preview
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Setup Bun
+        if: github.event.action != 'closed'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: bun install --frozen-lockfile
+
+      - name: Build static site
+        if: github.event.action != 'closed'
+        run: bun run build
+        env:
+          DOCS_BASE: /pr-preview/pr-${{ github.event.number }}/
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: .vitepress/dist

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -53,7 +53,7 @@ const structuredData = {
 
 export default withMermaid(
   defineConfig({
-    base: '/',
+    base: process.env.DOCS_BASE ?? '/',
     lang: 'en-US',
     title: SITE_NAME,
     titleTemplate: ':title | Inference Gateway',

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -53,7 +53,7 @@ const structuredData = {
 
 export default withMermaid(
   defineConfig({
-    base: process.env.DOCS_BASE ?? '/',
+    base: '/',
     lang: 'en-US',
     title: SITE_NAME,
     titleTemplate: ':title | Inference Gateway',

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.inference-gateway.com

--- a/preview-router/index.js
+++ b/preview-router/index.js
@@ -1,11 +1,11 @@
 export default {
-  fetch(request) {
+  fetch(request, env) {
     const url = new URL(request.url);
     const match = url.hostname.match(/^preview-([a-z0-9-]+)\.inference-gateway\.com$/);
     if (!match) {
       return new Response('Not found', { status: 404 });
     }
-    url.hostname = `${match[1]}.inference-gateway-docs.pages.dev`;
+    url.hostname = `${match[1]}-inference-gateway-docs.${env.WORKERS_SUBDOMAIN}.workers.dev`;
     return fetch(new Request(url, request));
   },
 };

--- a/preview-router/index.js
+++ b/preview-router/index.js
@@ -3,7 +3,7 @@ export default {
     const url = new URL(request.url);
     const match = url.hostname.match(/^preview-([a-z0-9-]+)\.inference-gateway\.com$/);
     if (!match) {
-      return new Response('Not found', { status: 404 });
+      return fetch(request);
     }
     url.hostname = `${match[1]}-inference-gateway-docs.${env.WORKERS_SUBDOMAIN}.workers.dev`;
     return fetch(new Request(url, request));

--- a/preview-router/index.js
+++ b/preview-router/index.js
@@ -1,0 +1,11 @@
+export default {
+  fetch(request) {
+    const url = new URL(request.url);
+    const match = url.hostname.match(/^preview-([a-z0-9-]+)\.inference-gateway\.com$/);
+    if (!match) {
+      return new Response('Not found', { status: 404 });
+    }
+    url.hostname = `${match[1]}.inference-gateway-docs.pages.dev`;
+    return fetch(new Request(url, request));
+  },
+};

--- a/preview-router/wrangler.jsonc
+++ b/preview-router/wrangler.jsonc
@@ -3,11 +3,11 @@
   "main": "index.js",
   "compatibility_date": "2026-08-10",
   "vars": {
-    "WORKERS_SUBDOMAIN": "FILL_AFTER_WRANGLER_LOGIN",
+    "WORKERS_SUBDOMAIN": "eden-reich",
   },
   "routes": [
     {
-      "pattern": "preview-*.inference-gateway.com/*",
+      "pattern": "*.inference-gateway.com/*",
       "zone_name": "inference-gateway.com",
     },
   ],

--- a/preview-router/wrangler.jsonc
+++ b/preview-router/wrangler.jsonc
@@ -11,4 +11,11 @@
       "zone_name": "inference-gateway.com",
     },
   ],
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true,
+    },
+  },
 }

--- a/preview-router/wrangler.jsonc
+++ b/preview-router/wrangler.jsonc
@@ -2,6 +2,9 @@
   "name": "docs-preview-router",
   "main": "index.js",
   "compatibility_date": "2026-08-10",
+  "vars": {
+    "WORKERS_SUBDOMAIN": "FILL_AFTER_WRANGLER_LOGIN",
+  },
   "routes": [
     {
       "pattern": "preview-*.inference-gateway.com/*",

--- a/preview-router/wrangler.jsonc
+++ b/preview-router/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "name": "docs-preview-router",
+  "main": "index.js",
+  "compatibility_date": "2026-08-10",
+  "routes": [
+    {
+      "pattern": "preview-*.inference-gateway.com/*",
+      "zone_name": "inference-gateway.com",
+    },
+  ],
+}

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-docs.inference-gateway.com

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "name": "inference-gateway-docs",
+  "compatibility_date": "2026-08-10",
+  "assets": {
+    "directory": ".vitepress/dist",
+    "not_found_handling": "404-page",
+  },
+  "routes": [
+    {
+      "pattern": "docs.inference-gateway.com",
+      "custom_domain": true,
+    },
+  ],
+  "preview_urls": true,
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,4 +12,11 @@
     },
   ],
   "preview_urls": true,
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true,
+    },
+  },
 }


### PR DESCRIPTION
## What

Moves the docs site deployment from GitHub Pages to Cloudflare Pages, and adds per-branch preview environments.

- **Production**: push to `main` deploys `.vitepress/dist` to the `inference-gateway-docs` Pages project (`docs.inference-gateway.com`).
- **Previews**: every PR deploys its branch and gets `https://preview-<branch>.inference-gateway.com`, commented on the PR. A wildcard-route Worker (`preview-router/`) maps the subdomain to the branch's Pages deployment. Free-tier TLS: single-label subdomains are covered by the zone's Universal SSL wildcard.
- **Teardown**: closing/merging the PR deletes that branch's preview deployments and updates the comment.
- Removes the GitHub Pages artifact flow and `public/CNAME`.

## One-time Cloudflare setup

1. Create Pages project `inference-gateway-docs` (production branch `main`) and add custom domain `docs.inference-gateway.com`.
2. Deploy `preview-router/` (`wrangler deploy`) — route `preview-*.inference-gateway.com/*`.
3. DNS: proxied wildcard record `*` so preview hosts resolve (the Worker route handles them).
4. Repo secrets: `CLOUDFLARE_API_TOKEN` (Pages:Edit), `CLOUDFLARE_ACCOUNT_ID`.
5. After first prod deploy: unpublish the GitHub Pages site.

no docs ticket: internal-only CI change
