### PR TITLE
fix(ci): install Bun in the preview teardown job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: .bun-version
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: .bun-version
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,6 +22,9 @@ jobs:
     name: Deploy preview
     if: github.event.action != 'closed'
     runs-on: ubuntu-24.04
+    environment:
+      name: preview-pr-${{ github.event.number }}
+      url: ${{ steps.alias.outputs.url }}
     steps:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token
@@ -48,7 +51,10 @@ jobs:
 
       - name: Resolve branch alias
         id: alias
-        run: echo "alias=$(echo "$GITHUB_HEAD_REF" | tr '/_.' '---' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-*$//')" >> "$GITHUB_OUTPUT"
+        run: |
+          alias=$(echo "$GITHUB_HEAD_REF" | tr '/_.' '---' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-*$//')
+          echo "alias=$alias" >> "$GITHUB_OUTPUT"
+          echo "url=https://preview-$alias.inference-gateway.com" >> "$GITHUB_OUTPUT"
 
       - name: Upload preview version
         run: bunx wrangler@4.123.0 versions upload --preview-alias "${{ steps.alias.outputs.alias }}"
@@ -97,6 +103,13 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Delete preview environment
+        run: |
+          gh api -X DELETE "repos/$GITHUB_REPOSITORY/environments/preview-pr-$PR"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ github.event.number }}
 
       - name: Comment removal
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -61,6 +61,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2.2.0
+        with:
+          bun-version-file: .bun-version
 
       - name: Resolve branch alias
         id: alias

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -57,12 +57,11 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Comment preview URL
-        uses: marocchino/sticky-pull-request-comment@v3.0.5
-        with:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          header: preview
-          message: |
-            :rocket: Preview deployed: https://preview-${{ steps.alias.outputs.alias }}.inference-gateway.com
+        run: |
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --edit-last --create-if-none --body ":rocket: Preview deployed: https://preview-${{ steps.alias.outputs.alias }}.inference-gateway.com"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ github.event.number }}
 
   teardown:
     name: Destroy preview
@@ -100,9 +99,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Comment removal
-        uses: marocchino/sticky-pull-request-comment@v3.0.5
-        with:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          header: preview
-          message: |
-            :wastebasket: Preview environment destroyed.
+        run: |
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --edit-last --create-if-none --body ":wastebasket: Preview environment destroyed."
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ github.event.number }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,6 +23,15 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
@@ -50,6 +59,7 @@ jobs:
       - name: Comment preview URL
         uses: marocchino/sticky-pull-request-comment@v3.0.5
         with:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           header: preview
           message: |
             :rocket: Preview deployed: https://preview-${{ steps.alias.outputs.alias }}.inference-gateway.com
@@ -59,6 +69,15 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
@@ -83,6 +102,7 @@ jobs:
       - name: Comment removal
         uses: marocchino/sticky-pull-request-comment@v3.0.5
         with:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           header: preview
           message: |
             :wastebasket: Preview environment destroyed.


### PR DESCRIPTION
The teardown job runs `bunx wrangler` but never installed Bun, so destroying previews failed with exit 127 (seen when PR #566 closed). Adds the missing setup-bun step and pins `oven-sh/setup-bun` to v2.2.0 across all workflows. The stale `ci-pr-previews` preview was tombstoned manually.

no docs ticket: internal-only CI change